### PR TITLE
remove stripping initial value

### DIFF
--- a/pkg/Tlog.go
+++ b/pkg/Tlog.go
@@ -262,10 +262,6 @@ func getx509Identity(publicKey string) (*X509, error) {
 		}
 		id := e.Id.String()
 		value := string(e.Value)
-		// remove the first 4 bytes from the value
-		if len(value) > 4 {
-			value = value[4:]
-		}
 		extension = append(extension, X509Extension{
 			ID:    id,
 			Value: value,


### PR DESCRIPTION
Once you merge this, could you recreate the entire dataset? I'm wondering if early on in the project, we had a bug that inserted some noise in these fields. In recent entries, there doesn't appear to be a need to strip the first four characters off of extensions.


Signed-off-by: Bob Callaway <bcallaway@google.com>