### PR TITLE
cli arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/bigquery v1.42.0
 	cloud.google.com/go/storage v1.27.0
+	github.com/urfave/cli/v2 v2.17.1
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 )
 
@@ -12,12 +13,15 @@ require (
 	cloud.google.com/go v0.104.0 // indirect
 	cloud.google.com/go/compute v1.7.0 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.5.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -200,12 +202,18 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/urfave/cli/v2 v2.17.1 h1:UzjDEw2dJQUE3iRaiNQ1VrVFbyAtKGH3VdkMoHA58V0=
+github.com/urfave/cli/v2 v2.17.1/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/Tlog.go
+++ b/pkg/Tlog.go
@@ -26,7 +26,7 @@ func NewTLog(host string) TLog {
 }
 
 // Size returns the size of the last entry.
-func (t *tlog) Size() (int64, error) {
+func (t *tlog) Size() (int, error) {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/log", t.host), nil)
 	if err != nil {
 		return 0, err
@@ -49,7 +49,7 @@ func (t *tlog) Size() (int64, error) {
 }
 
 // Entry returns the entry from the given tlogEntry.
-func (t *tlog) Entry(index int64) (Entry, error) {
+func (t *tlog) Entry(index int) (Entry, error) {
 	resp, err := http.Get(fmt.Sprintf("%s/api/v1/log/entries?logIndex=%d", t.host, index))
 	if err != nil {
 		return Entry{}, err

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -64,14 +64,14 @@ type importHashedrekord struct {
 }
 
 type tlog struct {
-	TreeSize int64 `json:"treeSize"`
+	TreeSize int `json:"treeSize"`
 	host     string
 }
 
 // TLog holds current root hash and size of the merkle tree used to store the log entries.
 type TLog interface {
-	Size() (int64, error)
-	Entry(index int64) (Entry, error)
+	Size() (int, error)
+	Entry(index int) (Entry, error)
 }
 type RekordData struct {
 	Hash RekorDataHash `json:"hash"`


### PR DESCRIPTION



Fixes #2 

```
 go run main.go -h
NAME:
   rekor-phren is a tool to update the BigQuery table and the bucket with the rekor entries - rekor-phren update -u <rekor url> -b <bucket name> -t <table name> -s <start> -e <end> -c <concurrency>

USAGE:
   rekor-phren is a tool to update the BigQuery table and the bucket with the rekor entries [global options] command [command options] [arguments...]

COMMANDS:
   update   update -u <rekor url> -b <bucket name> -t <table name> -s <start> -e <end> -c <concurrency>
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --bigquery-table-name value, -t value       (default: "rekor_test") [$PHREN_TABLE]
   --concurrency-level-update value, -c value  (default: 10) [$PHREN_CONCURRENCY]
   --end-index value, -e value                 (default: 0) [$PHREN_END]
   --gcs-bucket-name value, -b value           (default: openssf-rekor-test) [$PHREN_BUCKET]
   --help, -h                                  show help (default: false)
   --number-of-retries value, -r value         (default: 5) [$PHREN_RETRY]
   --rekor-url value, -u value                 (default: https://api.rekor.sigstore.dev) [$REKOR_URL]
   --start-index value, -s value               (default: 0) [$PHREN_START]

```

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>